### PR TITLE
Widen tls upper bound to <2.5

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # ChangeLog for `persistent-mysql-pure`
 
+## 1.0.4
++ Widen tls upper bound to <2.5 for tls 2.4.x compatibility
+
 ## 1.0.3
 + Support mysql-haskell 1.2.0 (tls 2.3.0, crypton 1.1.0, caching_sha2_password)
 + Widen dependency bounds for GHC 9.6/9.8/9.10/9.12

--- a/persistent-mysql-pure.cabal
+++ b/persistent-mysql-pure.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               persistent-mysql-pure
-version:            1.0.3
+version:            1.0.4
 license:            MIT
 license-file:       LICENSE
 author:
@@ -49,7 +49,7 @@ library
     resourcet >=1.1 && <1.4,
     text >=1.2 && <2.2,
     time >=1.5.0 && <1.15,
-    tls >=1.3.5 && <2.4,
+    tls >=1.3.5 && <2.5,
     transformers >=0.5 && <0.7,
     unliftio-core <0.3
 


### PR DESCRIPTION
## Summary
- Widen `tls` dependency upper bound from `<2.4` to `<2.5` for tls 2.4.x compatibility
- Patch bump version 1.0.3 → 1.0.4
- Update ChangeLog.md

## Test plan
- [ ] Verify cabal build succeeds with tls 2.4.x
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)